### PR TITLE
fix: Note Binder support for Zenodo DOI requires use of GitHub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Example repository structure for a PyHEP style "notebook talk"
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb)
 [![DOI](https://zenodo.org/badge/381276327.svg)](https://zenodo.org/badge/latestdoi/381276327)
 
+> N.B.: If you have questions on how to build a notebook talk, or the instructions below for sharing your notebook talk with Binder and preserving it with Zenodo please ask in the [GitHub Discussions](https://github.com/matthewfeickert/pyhep-notebook-talk-example/discussions)!
+
 ## Presentation Resources
 
 Before getting into the specifics of how to setup a repository to make it runnable with Binder and preservable with Zenodo, it is a good idea to first think about how to give a talk with a Jupyter notebook.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Example repository structure for a PyHEP style "notebook talk"
 Before getting into the specifics of how to setup a repository to make it runnable with Binder and preservable with Zenodo, it is a good idea to first think about how to give a talk with a Jupyter notebook.
 [Jim Pivarski](https://github.com/jpivarski) has a very good June 2021 PyHEP Topical meeting talk all about things to think about and consider when giving a talk with a Jupyter notebook: [How to give a good Jupyter talk](https://indico.cern.ch/event/1044648/)
 
-## Minimum Required Setup
+## Interactivity with Binder
+
+### Minimum Required Setup
 
 The minimum setup required is simply a repository with the Jupyter notebook that you'll be using and the `requirements.txt` or environment config file that is used to specify and install all of your code's dependencies.
 Note that it is rather important to **exactly** specify the requirements with `==` to avoid the repository code breaking in the future.
 
-## Recommended Setup
+### Recommended Setup
 
 Ideally, in addition to the minimum requirements, you'll also make the repository runnable on [Binder](https://mybinder.org/).
 The easiest way to do this is to simply ensure that _all_ of your dependencies are properly specified in your `requirements.txt` file and then to create a `binder` directory in the top level of the repository and place the `requirements.txt` file in it.
@@ -36,7 +38,7 @@ and its badge
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb)
 
-### Jupyter Lab Optional Launcher
+#### Jupyter Lab Optional Launcher
 
 If you'd like to have your Binder badge [launch into a JupyterLab environment](https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab) instead of Jupyter Notebook have the URL end with `?urlpath=lab/tree/path-to-the-notebook-you-want.ipynb`.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ If you'd like to have your Binder badge [launch into a JupyterLab environment](h
 
 ## Zenodo DOIs
 
+### Recommended System: Preservation with Binder support
+
 To preserve the repository with your talk as best as possible, have [Zenodo](https://zenodo.org/) build a Zenodo archive and mint a DOI for your repository.
 To do this:
 
@@ -52,7 +54,7 @@ To do this:
 3. Create a new GitHub release to trigger an archive capture.
 4. Add the minted DOI to your repository as a badge.
 
-This DOI can then be used by PyHEP to add your Zenodo archive to a PyHEP community colleciton on Zenodo. c.f. [PyHEP 2020's Zenodo community](https://zenodo.org/communities/pyhep2020) as an example.
+This DOI can then be used by PyHEP to add your Zenodo archive to a PyHEP community collection on Zenodo. c.f. [PyHEP 2020's Zenodo community](https://zenodo.org/communities/pyhep2020) as an example.
 
 You can create a Binder launch URL **from a Zenodo DOI** which will build the Docker image from the contents of the Zenodo archive.
 
@@ -65,6 +67,13 @@ https://mybinder.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipy
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipynb)
 
 Once talks are published, the Zenodo DOI is the preferred way to launch Binder links so that it will be stable far into the future.
+
+### Default system: Preservation without Binder support
+
+The preferred system for repository preservation on Zenodo is **not required** for your talk and repository to be preserved in the PyHEP Zenodo community collection.
+The PyHEP workshop organizers will manually archive any talks that do not already have Zenodo DOIs into a community collection.
+However, support for building Binder images from Zenodo DOIs is **only** available for projects that have been archived through the [Zenodo GitHub interface](https://zenodo.org/account/settings/github/).
+If a project is manually archived, the built Binder image will launch into a Jupyter server with a `.zip` file of the Zenodo archive in it, instead of the unpacked archive.
 
 ## Installation
 


### PR DESCRIPTION
```
* Note GitHub Discussions for use questions
* Make Binder a subsection
* Note the default system of manual archival on Zenodo by PyHEP organizers doesn't include Binder support from Zenodo DOI
    - Building Binder from Zenodo DOI for manually archived project will result in the archive zip file not being extracted
```

Example of Zenodo DOI from manual archival problem:

[mplhep: bridging Matplotlib and HEP from PyHEP 2020](https://doi.org/10.5281/zenodo.4147609) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4147609.svg)](https://doi.org/10.5281/zenodo.4147609)

the following Binder URL

https://mybinder.org/v2/zenodo/10.5281/zenodo.4147609/

will build a Binder image from the Zenodo archive but will launch the Jupyter server with `PyHEP2020_AndrzejNovak.zip` (the name of the archive zip file) being the only file in the server top level directory.