### PR TITLE
fix: Constrain notebook to be less than v7.0.0 for SSL BinderHub

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 awkward==2.4.4
 hist[plot]==2.7.2
 # Ensure Jupyter notebook
-notebook~=7.0
+notebook~=6.0
 jupyterlab~=4.0


### PR DESCRIPTION
* The SSL BinderHub is erroring on notebook v7.0.0 versions, so use notebook v6.X.