### PR TITLE
docs: Note CILogon identify provider restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Example repository structure for a PyHEP style "notebook talk"
 > **PyHEP 2023 Update:** PyHEP 2023 will be using a BinderHub that has been deployed by IRIS-HEP's [Scalable Systems Laboratory](https://iris-hep.org/ssl.html) (SSL) at https://binderhub.ssl-hep.org/ which requires authentication with CILogon.
 > The instructions are the same as from previous years, with the exception of all urls that use `mybinder.org` will now use `binderhub.ssl-hep.org`.
 > A walkthrough video of the workflow is also [available on the HSF YouTube channel](https://youtu.be/4D6eYHNQip0).
+>
+> **N.B.:** The CILogon identity providers that will work for the SSL BinderHub are verified institutions with signed agreements.
+> This means that CERN and any university will work, but Google and GitHub will not.
+> If you do not have an affiliation with a verified institution you won't be able to use the SSL BinderHub but you can follow along on the public mybinder BinderHub at http://mybinder.org/.
 
 Before getting into the specifics of how to setup a repository to make it runnable with Binder and preservable with Zenodo, it is a good idea to first think about how to give a talk with a Jupyter notebook.
 [Jim Pivarski](https://github.com/jpivarski) has a very good June 2021 PyHEP Topical meeting talk all about things to think about and consider when giving a talk with a Jupyter notebook: [How to give a good Jupyter talk](https://indico.cern.ch/event/1044648/).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Example repository structure for a PyHEP style "notebook talk"
 > A walkthrough video of the workflow is also [available on the HSF YouTube channel](https://youtu.be/4D6eYHNQip0).
 >
 > **N.B.:** The CILogon identity providers that will work for the SSL BinderHub are verified institutions with signed agreements.
-> This means that CERN and any university will work, but Google and GitHub will not.
+> This means that CERN and any university will work, but Google and GitHub may not.
 > If you do not have an affiliation with a verified institution you won't be able to use the SSL BinderHub but you can follow along on the public mybinder BinderHub at http://mybinder.org/.
 
 Before getting into the specifics of how to setup a repository to make it runnable with Binder and preservable with Zenodo, it is a good idea to first think about how to give a talk with a Jupyter notebook.


### PR DESCRIPTION
* Need to use verified institutions with signed agreements for CILogon to SSL BinderHub.