### PR TITLE
docs: Use labpath for providing notebook launch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ If a user just clicks that badge, the Binder build will run if there already isn
 Below is an example of a URL that will launch the `talk.ipynb` notebook in this repository into a JupyterLab environment.
 
 ```
-https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?labpath=talk.ipynb
+https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb
 ```
 
 and its badge
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?labpath=talk.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb)
 
 #### Jupyter Lab Optional Launcher
 
@@ -70,10 +70,10 @@ You can create a Binder launch URL **from a Zenodo DOI** which will build the Do
 The following URL and badge will launch a Binder session built from the Zenodo archive
 
 ```
-https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?labpath=talk.ipynb
+https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipynb
 ```
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?labpath=talk.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipynb)
 
 Once talks are published, the Zenodo DOI is the preferred way to launch Binder links so that it will be stable far into the future.
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ and its badge
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb)
 
-#### Jupyter Lab Optional Launcher
+#### Jupyter Lab file browser visible at launch
 
-If you'd like to have your Binder badge [launch into a JupyterLab environment](https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab) instead of Jupyter Notebook have the URL end with `?urlpath=lab/tree/path-to-the-notebook-you-want.ipynb`.
+By default if you provide a path for a notebook to open to BinderHub it will launch it in a "`labpath`" view [JupyterLab environment](https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab) with the notebook as the only view (the JupyterLab file browser will be minimized) and the URL will end with `?labpath=path-to-the-notebook-you-want.ipynb`.
+If you would like to have the JupyterLab browser be visible by default you can use instead a `urlpath` view and end the URL with `?urlpath=lab/tree/path-to-the-notebook-you-want.ipynb`
 
 ## Zenodo DOIs
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ If a user just clicks that badge, the Binder build will run if there already isn
 Below is an example of a URL that will launch the `talk.ipynb` notebook in this repository into a JupyterLab environment.
 
 ```
-https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb
+https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?labpath=talk.ipynb
 ```
 
 and its badge
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?urlpath=lab/tree/talk.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/gh/matthewfeickert/pyhep-notebook-talk-example/HEAD?labpath=talk.ipynb)
 
 #### Jupyter Lab Optional Launcher
 
@@ -70,10 +70,10 @@ You can create a Binder launch URL **from a Zenodo DOI** which will build the Do
 The following URL and badge will launch a Binder session built from the Zenodo archive
 
 ```
-https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipynb
+https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?labpath=talk.ipynb
 ```
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?urlpath=lab/tree/talk.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://binderhub.ssl-hep.org/v2/zenodo/10.5281/zenodo.5041728/?labpath=talk.ipynb)
 
 Once talks are published, the Zenodo DOI is the preferred way to launch Binder links so that it will be stable far into the future.
 


### PR DESCRIPTION
* Provide instructions on using either the 'labpath' view or 'urlpath' view
  for the default JupyterLab interface.
   - c.f. https://mybinder.readthedocs.io/en/latest/howto/user_interface.html#jupyterlab