### PR TITLE
chore: Update binder runtime requirements

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
-awkward==2.4.4
-hist[plot]==2.7.2
+awkward==2.6.6
+hist[plot]==2.7.3
 # Ensure Jupyter notebook
-notebook~=6.0
+notebook~=7.0
 jupyterlab~=4.0

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.12


### PR DESCRIPTION
* Update Python to 3.12.
* Update dependencies to latest releases