### PR TITLE
fix: Use Python 3.11 to support SSL BinderHub

### DIFF
--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.12
+python-3.11


### PR DESCRIPTION
* The SSL BinderHub doesn't support Python 3.12 yet outside of using a Conda environment.yml.