### PR TITLE
fix: Revert to notebook v6.x for SSL JupyterHub

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,6 @@
 awkward==2.6.6
 hist[plot]==2.7.3
 # Ensure Jupyter notebook
-notebook~=7.0
+# SSL JupyterHub has a bug with notebook v7.0
+notebook~=6.0
 jupyterlab~=4.0


### PR DESCRIPTION
* There seems to be a bug with notebook v7.x on the SSL JupyterHub deployment, so use notebook v6.x for the time being.