### PR TITLE
docs: Note PyHEP 2025 will use SSL BinderHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example repository structure for a PyHEP style "notebook talk"
 
 ## Presentation Resources
 
-> **PyHEP 2024 Update:** PyHEP 2024 will be using a BinderHub that has been deployed by IRIS-HEP's [Scalable Systems Laboratory](https://iris-hep.org/ssl.html) (SSL) at https://binderhub.ssl-hep.org/ which requires authentication with CILogon.
+> **PyHEP 2025 Update:** PyHEP 2025 will be using a BinderHub that has been deployed by IRIS-HEP's [Scalable Systems Laboratory](https://iris-hep.org/ssl.html) (SSL) at https://binderhub.ssl-hep.org/ which requires authentication with CILogon.
 > The instructions are the same as from previous years, with the exception of all urls that use `mybinder.org` will now use `binderhub.ssl-hep.org`.
 > A walkthrough video of the workflow is also [available on the HSF YouTube channel](https://youtu.be/4D6eYHNQip0).
 >
@@ -80,7 +80,7 @@ If you would like to have the JupyterLab browser be visible by default you can u
 ## Local Testing
 
 To test your Binderized setup locally you can use the [`repo2docker`](https://github.com/jupyterhub/repo2docker) command line utility.
-Install [`jupyter-repo2docker`] either [from conda-forge](https://github.com/conda-forge/jupyter-repo2docker-feedstock)
+Install `jupyter-repo2docker` either [from conda-forge](https://github.com/conda-forge/jupyter-repo2docker-feedstock)
 
 ```
 pixi global install jupyter-repo2docker

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ To do this:
 
 1. Create an account on [zenodo.org](https://zenodo.org/).
 2. [Follow the instructions](https://zenodo.org/account/settings/github/) on syncing GitHub repositories that you control with Zenodo.
-3. Create a new GitHub release (e.g. "pyhep-2024) to trigger an archive capture.
+3. Create a new GitHub release (e.g. "pyhep-2025) to trigger an archive capture.
 4. Add the minted DOI to your repository as a badge.
 
-This DOI can then be used by the PyHEP workshop organizers to add your Zenodo archive to the relevant PyHEP community collection on Zenodo, namely [PyHEP 2024's Zenodo community](https://zenodo.org/communities/pyhep2024).
+This DOI can then be used by the PyHEP workshop organizers to add your Zenodo archive to the relevant PyHEP community collection on Zenodo, namely [PyHEP 2025's Zenodo community](https://zenodo.org/communities/pyhep2025).
 
 You can create a Binder launch URL **from a Zenodo DOI** which will build the Docker image from the contents of the Zenodo archive.
 


### PR DESCRIPTION
* Note BinderHub use.
   - c.f. https://binderhub.ssl-hep.org/
* Note PyHEP 2025 Zenodo community.